### PR TITLE
Inform about GitHub Discussions and redirect after 10 seconds

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,23 @@
 <html>
-	<head>
+	<body>
+		<p>
+			talk.manageiq.org has been replaced by <a href="https://github.com/ManageIQ/manageiq/discussions">GitHub Discussions</a>. Please start any new discussions there.
+		<p>
+		<p>
+			Redirecting to <a id="link" href="#">this page</a> on the internet archive in <span id="counter">10</span> seconds...
+		<p>
 		<script type="application/javascript">
-			window.location.replace("https://web.archive.org/web/" + window.location.href);
+			const link = "https://web.archive.org/web/" + window.location.href;
+			document.querySelector("#link").setAttribute('href', link);
+
+			setInterval(function() {
+				let counter = document.querySelector("#counter");
+				let count = counter.textContent * 1 - 1;
+				counter.textContent = count;
+				if (count <= 0) {
+					window.location.replace(link);
+				}
+			}, 1000);
 		</script>
-	</head>
+	</body>
 </html>

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 Redirection for the archived https://talk.manageiq.org Discourse Forum
 
+talk.manageiq.org has been replaced by [GitHub Discussions](https://github.com/ManageIQ/manageiq/discussions). Please start any new discussions there.


### PR DESCRIPTION
@bdunne Please review.

I chose 10 seconds because it gives the reader enough time to read everything and then ~5 more seconds after that.  Otherwise it redirects right when they finish reading or even a little before.

Not sure on the text - figured this is a start and we can discuss.

![Mozilla_Firefox](https://user-images.githubusercontent.com/52120/208742031-e3d04634-0425-4681-a3a9-2ef6a1307aa3.png)
