### PR TITLE
Clear the interval when the counter elapses

### DIFF
--- a/redirect.js
+++ b/redirect.js
@@ -1,11 +1,12 @@
 const link = "https://web.archive.org/web/" + window.location.href;
 document.querySelector("#link").setAttribute('href', link);
 
-setInterval(function() {
+const interval = setInterval(function() {
 	let counter = document.querySelector("#counter");
 	let count = counter.textContent * 1 - 1;
 	counter.textContent = count;
 	if (count <= 0) {
+		clearInterval(interval);
 		window.location.replace(link);
 	}
 }, 1000);


### PR DESCRIPTION
Without this change, the counter can go into the negative, which looks weird. More importantly, however, if the replace is too slow, then it will keep try to replace every second, which will flash the screen. No need to keep doing that once we hit 0.

@bdunne Please review.